### PR TITLE
feat: applying filters when selecting interior subactegories

### DIFF
--- a/src/components/service/ServiceItem.tsx
+++ b/src/components/service/ServiceItem.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import { useServiceStore } from "store";
 
+import { tailTextureList, wallPaperTextureList } from "./data";
 interface Data {
   category: string[];
   id: string;
@@ -14,11 +15,25 @@ interface Props {
 }
 
 export const ServiceItem = ({ data, type }: Props): JSX.Element => {
-  const { setTile, setWallPaper } = useServiceStore((state) => state);
+  const { setTile, setWallPaper, interiorSelecteIndex } = useServiceStore((state) => state);
   const imgUrl = process.env.REACT_APP_SUPABASE_STORAGE_URL as string;
-  const getItemData = (image: "tile" | "wallPaper"): void => {
-    // console.log(type);
 
+  // 페이지 마운트 되었을때, 언마운트 되었을때
+  // 인테리어 비쥬얼에 타일, 벽지 적용한걸 초기화하는 useEffect 입니다.
+  useEffect(() => {
+    // console.log("페이지 마운트됨");
+    setWallPaper("");
+    setTile("");
+    return () => {
+      // console.log("페이지 언마운트됨");
+      setWallPaper("");
+      setTile("");
+    };
+  }, []);
+
+  // 클릭한 이미지를 zustand로 전역 관리합니다.
+  // 저장된 이미지는 왼쪽 인테리어 비쥬얼에 뿌려주게 됩니다.
+  const getItemData = (image: string): void => {
     if (type === "wallPaper") {
       setWallPaper(image as "wallPaper");
     }
@@ -27,9 +42,50 @@ export const ServiceItem = ({ data, type }: Props): JSX.Element => {
     }
   };
 
+  // type 에 따라 CHECK_DATA의 값이 바뀝니다.
+  // 이 값은 벽지 타이틀이름 배열과, 바닥재 타이틀이름 배열입니다.
+  const CHECK_DATA = type === "wallPaper" ? tailTextureList : wallPaperTextureList;
+
+  // 클릭시 스위치에서 보내준 값으로 필터를 돌리는 함수입니다.
+  // 그 함수는 변수에 저장됩니다. (useState를 사용하면 무한 렌더링에 걸립니다.)
+  let filterData: Data[] = [];
+  const filterDate = (typeName?: string) => {
+    if (typeof typeName === "string") {
+      const FILTER_DATA = data.filter((el) => {
+        return el.texture === typeName;
+      });
+      filterData = FILTER_DATA;
+    }
+  };
+
+  // 인테리어 헤더부분 리스트아이템 선택시 그 선택아이템의 값을 영어로 변환해 filterDate 에 매개변수로 전달합니다.
+  // 값이 없을경우 filterDate = data(전체데이터) 로 할당됩니다.
+  let chaingeName: string = "";
+  switch (CHECK_DATA[interiorSelecteIndex]) {
+    case CHECK_DATA[0]:
+      chaingeName = CHECK_DATA[0] === "장판" ? "wallPaper" : "floorMat";
+      filterDate(chaingeName);
+      break;
+    case CHECK_DATA[1]:
+      chaingeName = CHECK_DATA[1] === "마루" ? "paint" : "floor";
+      filterDate(chaingeName);
+      break;
+    case CHECK_DATA[2]:
+      chaingeName = CHECK_DATA[2] === "데코타일" ? "tile" : "decorationtile";
+      filterDate(chaingeName);
+      break;
+    case CHECK_DATA[3]:
+      chaingeName = CHECK_DATA[3] === "포세린" ? "poserin" : "poserin";
+      filterDate(chaingeName);
+      break;
+    default:
+      filterData = data;
+      break;
+  }
+
   return (
     <>
-      {data.map((item) => {
+      {filterData.map((item) => {
         const { id, image } = item;
         return (
           <li
@@ -39,7 +95,7 @@ export const ServiceItem = ({ data, type }: Props): JSX.Element => {
             key={id}
             className="bg-gray-200 w-[120px] h-[120px] cursor-pointer"
           >
-            <img src={`${imgUrl}${image}`} alt="미리보기 이미지" />
+            <img src={`${imgUrl}${image}`} className="w-[120px] h-[120px]" alt={` ${type} 미리보기 이미지`} />
           </li>
         );
       })}

--- a/src/components/service/TextureTitle.tsx
+++ b/src/components/service/TextureTitle.tsx
@@ -1,14 +1,35 @@
 import React from "react";
+
+import { useServiceStore } from "store";
+
 interface Props {
   data: string[];
 }
 
 const TextureTitle = ({ data }: Props): JSX.Element => {
+  const { interiorSelecteIndex, setInteriorSelecteIndex } = useServiceStore((state) => state);
+
+  // 벽지, 타일  세부카테고리 선택시 선택한 아이템의 인덱스를 zustand로 저장하는 함수입니다.
+  const onTextureTitleHandler = (index: number) => {
+    // 저장된 인덱스 값과 매개변수 인덱스의 값이 다를때 저장합니다.
+    if (interiorSelecteIndex !== index) {
+      setInteriorSelecteIndex(index);
+      return;
+    }
+    // 저장된값이 기존값과 같으면 -1을 저장합니다.
+    setInteriorSelecteIndex(-1);
+  };
+  // console.log(interiorSelecteIndex);
   return (
     <>
-      {/* props로 받아온값을 map돌려 리턴하는 컴포넌트입니다. */}
-      {data.map((item) => (
-        <span key={item} className="hover:cursor-pointer">
+      {data.map((item, index) => (
+        <span
+          onClick={() => {
+            onTextureTitleHandler(index);
+          }}
+          key={item}
+          className={`hover:cursor-pointer ${interiorSelecteIndex === index ? "text-[#222]" : ""} `}
+        >
           {item}
         </span>
       ))}

--- a/src/pages/Service.tsx
+++ b/src/pages/Service.tsx
@@ -44,18 +44,13 @@ export const Service = () => {
     setWallPaperBg(imgUrl + wallPaper);
     setTileBg(imgUrl + tile);
   }, [wallPaper, tile]);
-  //   console.log("wallPaper", wallPaper);
-  //   console.log("tile", tile);
 
   //   사이즈 컨트롤세터함수
 
   const onClickTypeSwitch = (type: "tile" | "wallPaper") => {
-    // console.log(type);
     setTypeCheck(type);
   };
 
-  console.log(wallPaperBg);
-  console.log(tileBg);
   return (
     <>
       <div className="flex flex-col m-20">
@@ -72,21 +67,21 @@ export const Service = () => {
                     backgroundImage: `url(${wallPaperBg})`,
                     backgroundSize: `${70}px, ${70}px`,
                   }}
-                  className={`w-[500px] h-[200px] translate-x-[25px] translate-y-[6px] border-b-2 border-[1px] border-black`}
+                  className={`w-[500px] h-[200px] bg-white translate-x-[25px] translate-y-[6px] border-b-2 border-[1px] border-black`}
                 >
                   벽지벽지
                 </div>
                 {/* 타일 */}
                 <div
                   style={{ backgroundImage: `url(${tileBg})`, backgroundSize: `${70}px, ${70}px` }}
-                  className={`w-[550px] h-[200px]  rotate-x-[50deg] -translate-y-[30px] transform-style-3d border-[1px] border-black`}
+                  className={`w-[550px] h-[200px] bg-white rotate-x-[50deg] -translate-y-[30px] transform-style-3d border-[1px] border-black`}
                 >
                   타일타일
                 </div>
               </div>
             </div>
             <div className="h-[603px] w-[860px]">
-              {/* 타일 헤더 */}
+              {/* 인테리어 헤더 */}
               <div className="flex mb-6 h-[35px] text-gray-300 gap-3">
                 <span
                   className={
@@ -116,23 +111,25 @@ export const Service = () => {
                 {checkType === "wallPaper" ? (
                   <>
                     {/* 벽지 종류 목록 */}
-                    <TextureTitle data={tailTextureList} />
+                    <TextureTitle data={wallPaperTextureList} />
                   </>
                 ) : checkType === "tile" ? (
                   <>
                     {/* 타일 종류 목록 */}
-                    <TextureTitle data={wallPaperTextureList} />
+                    <TextureTitle data={tailTextureList} />
                   </>
                 ) : (
                   <></>
                 )}
               </div>
 
+              {/* 인테리어 바디 */}
               <div className="h-[392px] mb-10 overflow-auto">
                 <ul className="flex flex-wrap w-full gap-x-4 gap-y-4">
                   {checkType === "wallPaper" ? (
                     <ServiceItem type={checkType} data={wallData} />
                   ) : (
+                    // sift
                     <ServiceItem type={checkType} data={taleData} />
                   )}
 

--- a/src/store/useServiceStore.ts
+++ b/src/store/useServiceStore.ts
@@ -3,6 +3,9 @@ import { create } from "zustand";
 interface Store {
   checkType: "tile" | "wallPaper";
   setTypeCheck: (type: "tile" | "wallPaper") => void;
+  // 인테리어 헤더
+  interiorSelecteIndex: number;
+  setInteriorSelecteIndex: (index: number) => void;
   // 벽지
   wallPaper: string;
   setWallPaper: (img: string) => void;
@@ -18,6 +21,11 @@ export const useServiceStore = create<Store>()((set) => ({
   checkType: "wallPaper",
   setTypeCheck: (type) => {
     set((state) => ({ checkType: (state.checkType = type) }));
+  },
+  // 인테리어 헤더
+  interiorSelecteIndex: -1,
+  setInteriorSelecteIndex: (index) => {
+    set((state) => ({ interiorSelecteIndex: (state.interiorSelecteIndex = index) }));
   },
   //  벽지
   wallPaper: "",


### PR DESCRIPTION
카테고리 선택시, 해당 카테고리에 맞는 목록을 필터 걸어서 반환합니다.
카테고리 선택시, 카테고리의 인텍스를 추출해서 사용할 수 있는 전역관리 함수를 만들었습니다. 왼쪽 인테리어 비쥬얼에 흰색 배경을 추가했습니다.
페이지를 마운트, 언마운트되었을때 이전에 추가해둔 벽지, 타일이 남아있던 현상을 방지했습니다.