### PR TITLE
fix: serviseImgSrcFix Fix

### DIFF
--- a/src/components/service/ServiceSelectItem.tsx
+++ b/src/components/service/ServiceSelectItem.tsx
@@ -2,8 +2,6 @@ import React from "react";
 
 import { useServiceStore } from "store";
 
-import { SELECT_BORDER_COLOR } from "./data";
-
 interface Props {
   image: string;
   id: string;
@@ -37,15 +35,15 @@ export const ServiceSelectItem = ({ image, id }: Props): JSX.Element => {
   /**
    * 왼쪽 벽지 클릭시 나오는 보더
    */
-  const CHECK_LEFT_ITEM_BORDER = onClickItemBorder.left === id ? `border-[${SELECT_BORDER_COLOR}]` : "";
+  const CHECK_LEFT_ITEM_BORDER = onClickItemBorder.left === id ? `border-[#666]` : "";
   /**
    * 오른쪽 벽지 클릭시 나오는 보더
    */
-  const CHECK_RIGHT_ITEM_BORDER = onClickItemBorder.right === id ? `border-[${SELECT_BORDER_COLOR}]` : "";
+  const CHECK_RIGHT_ITEM_BORDER = onClickItemBorder.right === id ? `border-[#666]` : "";
   /**
    * 타일 클릭시 나오는 보더
    */
-  const CHECK_TILE_ITEM_BORDER = onClickItemBorder.tile === id ? `border-[${SELECT_BORDER_COLOR}]` : "";
+  const CHECK_TILE_ITEM_BORDER = onClickItemBorder.tile === id ? `border-[#666]` : "";
   /**
    * 왼쪽 벽지, 오른쪽 벽지가 같을경우나오는 보더
    */
@@ -62,7 +60,7 @@ export const ServiceSelectItem = ({ image, id }: Props): JSX.Element => {
       >
         <img
           src={`${STORAGE_URL}${image}`}
-          className={`block interior-item border-8 border-white ${CHECK_LEFT_ITEM_BORDER} ${CHECK_RIGHT_ITEM_BORDER} ${CHECK_TILE_ITEM_BORDER} drag-none
+          className={`block interior-item border-4 border-white ${CHECK_LEFT_ITEM_BORDER} ${CHECK_RIGHT_ITEM_BORDER} ${CHECK_TILE_ITEM_BORDER} drag-none
            `}
           alt={` ${checkType} 미리보기 이미지`}
         />

--- a/src/components/service/data.tsx
+++ b/src/components/service/data.tsx
@@ -31,7 +31,7 @@ const SELECT_CUSTOM_INDEX: number = 5;
 /**
  * 색상값을 지정해둔 변수입니다. 벽지, 타일을 클릭시 들어가는 색상 헥사코드입니다.
  */
-const SELECT_BORDER_COLOR = "#666";
+// const SELECT_BORDER_COLOR = "#666";
 
 /**
  * 기본 백그라운드 사이즈입니다 70
@@ -50,7 +50,6 @@ export {
   BG_MAGNIFICATION_LANGTH,
   BG_DEFAULT_SIZE,
   BG_MAGNIFICATION,
-  SELECT_BORDER_COLOR,
   WALLPAPER_TEXTURE_LIST,
   TILE_TEXTURE_LIST,
   RESOURES_CALCULATOR_LIST,

--- a/src/pages/Service.tsx
+++ b/src/pages/Service.tsx
@@ -36,6 +36,7 @@ export const Service = () => {
 
   const { onOpenModal } = useModalStore((state) => state);
   const {
+    resetClickItemBordder,
     wallPaper,
     tile,
     wallpaperPaint,
@@ -83,10 +84,12 @@ export const Service = () => {
     resetWallPaper();
     resetWallpaperPaint();
     resetTile();
+    resetClickItemBordder();
     return () => {
       resetWallPaper();
       resetWallpaperPaint();
       resetTile();
+      resetClickItemBordder();
     };
   }, []);
 

--- a/src/store/useServiceStore.ts
+++ b/src/store/useServiceStore.ts
@@ -1,6 +1,5 @@
 import { BG_MAGNIFICATION_LANGTH } from "components";
 import { create } from "zustand";
-
 type WallOrTile = "tile" | "wallPaper";
 export type SelectBg = "leftWall" | "rightWall" | "tile";
 
@@ -173,25 +172,25 @@ export const useServiceStore = create<Store>()((set) => ({
     if (type === "leftWall") {
       set((state) => ({
         selectBgSize:
-          state.selectBgSize.leftWall !== BG_MAGNIFICATION_LANGTH
+          state.selectBgSize.leftWall !== BG_MAGNIFICATION_LANGTH - 1
             ? { ...state.selectBgSize, leftWall: state.selectBgSize.leftWall + 1 }
-            : { ...state.selectBgSize, leftWall: BG_MAGNIFICATION_LANGTH },
+            : { ...state.selectBgSize, leftWall: BG_MAGNIFICATION_LANGTH - 1 },
       }));
     }
     if (type === "rightWall") {
       set((state) => ({
         selectBgSize:
-          state.selectBgSize.rightWall !== BG_MAGNIFICATION_LANGTH
+          state.selectBgSize.rightWall !== BG_MAGNIFICATION_LANGTH - 1
             ? { ...state.selectBgSize, rightWall: state.selectBgSize.rightWall + 1 }
-            : { ...state.selectBgSize, rightWall: BG_MAGNIFICATION_LANGTH },
+            : { ...state.selectBgSize, rightWall: BG_MAGNIFICATION_LANGTH - 1 },
       }));
     }
     if (type === "tile") {
       set((state) => ({
         selectBgSize:
-          state.selectBgSize.tile !== BG_MAGNIFICATION_LANGTH
+          state.selectBgSize.tile !== BG_MAGNIFICATION_LANGTH - 1
             ? { ...state.selectBgSize, tile: state.selectBgSize.tile + 1 }
-            : { ...state.selectBgSize, tile: BG_MAGNIFICATION_LANGTH },
+            : { ...state.selectBgSize, tile: BG_MAGNIFICATION_LANGTH - 1 },
       }));
     }
   },


### PR DESCRIPTION
data의 변수를 수정했습니다.
타일,벽지 아이템 클릭시 보더가 나오지 아니하던 현상을 수정했습니다.
클릭된 아이템 컴포넌트가 언마운트 되었을시, 보더가 남아있던 현상을 수정하였습니다.
bgsize 확대, 축소 버튼시 확대버튼이 최댓값이 되었을때 축소버튼을 누를시 씹히던 현상을 수정하였습니다.