### PR TITLE
fix: InteriorSelecteIndex index 문제, ResourcesCalculator header 문제 해결

### DIFF
--- a/src/components/service/InteriorTitle.tsx
+++ b/src/components/service/InteriorTitle.tsx
@@ -9,10 +9,11 @@ interface Props {
 }
 
 const InteriorTitleMemoization = ({ children, type }: Props): JSX.Element => {
-  const { checkType, setTypeCheck } = useServiceStore((state) => state);
+  const { checkType, setTypeCheck, setInteriorSelecteIndex } = useServiceStore((state) => state);
 
   const onClickTypeSwitch = useCallback((type: WallOrTileOrFurniture) => {
     setTypeCheck(type);
+    setInteriorSelecteIndex(0);
   }, []);
 
   return (

--- a/src/components/service/data.tsx
+++ b/src/components/service/data.tsx
@@ -33,7 +33,7 @@ const WALLPAPER_TEXTURE_LIST: string[] = ["전체 보기", "벽지", "타일", "
 const TILE_TEXTURE_LIST: string[] = ["전체 보기", "장판", "마루", "포세린", "데코타일", "셀프조합"];
 const FURNITURE_LIST: string[] = ["전체 보기", "가구", "조명"];
 
-const RESOURCES_CALCULATOR_LIST: string[] = ["벽지", "타일, 가구"];
+const RESOURCES_CALCULATOR_LIST: string[] = ["벽지", "타일"];
 
 const SELECT_PAINT_INDEX: number = 4;
 


### PR DESCRIPTION
interiorSelecteIndex 의 값이 바뀔때마다 0으로(전체) 로 초기화 되도록 만들었습니다. ResourcesCalculator header의 이름부분을 수정했습니다.