### PR TITLE
fix: header title

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -145,7 +145,10 @@ const HeaderMemoization = () => {
         } transition-colors duration-500 ease-in-out`}
       >
         <div className="w-[1280px] contents-between items-center">
-          <Link to="/" className="flex items-center text-[32px] font-title gap-4 py-4 font-medium">
+          <Link
+            to={(windowWidth as number) >= 767 ? "/" : pathname}
+            className="flex items-center text-[32px] font-title gap-4 my-4 font-medium"
+          >
             {(windowWidth as number) >= 767 ? (
               "STILE"
             ) : (


### PR DESCRIPTION
뷰포트가 768 밑으로 내려갈시 헤더타이틀의 여백을 패딩 => 마진으로 바꾸었습니다.
뷰포트가 768 밑으로 내려갈시 헤더타이틀의 Link to 속성을 삼항연산자로 바꾸었습니다.